### PR TITLE
Fix debug builds and add CI for gcc 9 and clang 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ jobs:
         env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8
       - <<: *linux
         stage: conan-linux
+        env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9
+      - <<: *linux
+        stage: conan-linux
         env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=conanio/clang39
       - <<: *linux
         stage: conan-linux
@@ -45,6 +48,9 @@ jobs:
       - <<: *linux
         stage: conan-linux
         env: CONAN_CLANG_VERSIONS=7.0 CONAN_DOCKER_IMAGE=conanio/clang7
+      - <<: *linux
+        stage: conan-linux
+        env: CONAN_CLANG_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/clang8
       - <<: *osx
         stage: conan-osx
         osx_image: xcode7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+env:
+   global:
+     - CONAN_ARCHS=x86_64
 linux: &linux
    os: linux
    dist: xenial
@@ -8,68 +11,43 @@ linux: &linux
 osx: &osx
    os: osx
    language: generic
-
-stages:
-  - conan-linux
-  - conan-osx
-
-jobs:
+matrix:
    include:
       - <<: *linux
-        stage: conan-linux
         env: CONAN_GCC_VERSIONS=4.9 CONAN_DOCKER_IMAGE=conanio/gcc49
       - <<: *linux
-        stage: conan-linux
         env: CONAN_GCC_VERSIONS=5 CONAN_DOCKER_IMAGE=conanio/gcc5
       - <<: *linux
-        stage: conan-linux
         env: CONAN_GCC_VERSIONS=6 CONAN_DOCKER_IMAGE=conanio/gcc6
       - <<: *linux
-        stage: conan-linux
         env: CONAN_GCC_VERSIONS=7 CONAN_DOCKER_IMAGE=conanio/gcc7
       - <<: *linux
-        stage: conan-linux
         env: CONAN_GCC_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/gcc8
       - <<: *linux
-        stage: conan-linux
         env: CONAN_GCC_VERSIONS=9 CONAN_DOCKER_IMAGE=conanio/gcc9
       - <<: *linux
-        stage: conan-linux
         env: CONAN_CLANG_VERSIONS=3.9 CONAN_DOCKER_IMAGE=conanio/clang39
       - <<: *linux
-        stage: conan-linux
         env: CONAN_CLANG_VERSIONS=4.0 CONAN_DOCKER_IMAGE=conanio/clang40
       - <<: *linux
-        stage: conan-linux
         env: CONAN_CLANG_VERSIONS=5.0 CONAN_DOCKER_IMAGE=conanio/clang50
       - <<: *linux
-        stage: conan-linux
         env: CONAN_CLANG_VERSIONS=6.0 CONAN_DOCKER_IMAGE=conanio/clang60
       - <<: *linux
-        stage: conan-linux
         env: CONAN_CLANG_VERSIONS=7.0 CONAN_DOCKER_IMAGE=conanio/clang7
       - <<: *linux
-        stage: conan-linux
         env: CONAN_CLANG_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/clang8
       - <<: *osx
-        stage: conan-osx
-        osx_image: xcode7.3
-        env: CONAN_APPLE_CLANG_VERSIONS=7.3
-      - <<: *osx
-        stage: conan-osx
         osx_image: xcode8.3
         env: CONAN_APPLE_CLANG_VERSIONS=8.1
       - <<: *osx
-        stage: conan-osx
         osx_image: xcode9
         env: CONAN_APPLE_CLANG_VERSIONS=9.0
       - <<: *osx
-        stage: conan-osx
         osx_image: xcode9.4
         env: CONAN_APPLE_CLANG_VERSIONS=9.1
       - <<: *osx
-        stage: conan-osx
-        osx_image: xcode10.1
+        osx_image: xcode10.3
         env: CONAN_APPLE_CLANG_VERSIONS=10.0
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,6 @@ matrix:
       - <<: *linux
         env: CONAN_CLANG_VERSIONS=8 CONAN_DOCKER_IMAGE=conanio/clang8
       - <<: *osx
-        osx_image: xcode8.3
-        env: CONAN_APPLE_CLANG_VERSIONS=8.1
-      - <<: *osx
         osx_image: xcode9
         env: CONAN_APPLE_CLANG_VERSIONS=9.0
       - <<: *osx

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 import shutil
+import re
 
 from conans import ConanFile, tools, AutoToolsBuildEnvironment
 from conans.errors import ConanInvalidConfiguration
@@ -65,7 +66,11 @@ class FontconfigConan(ConanFile):
         shutil.copyfile(os.path.join(freetype_path, "lib", "pkgconfig", "freetype2.pc"), "freetype2.pc")
         tools.replace_prefix_in_pc_file("freetype2.pc", freetype_path)
         if self.settings.build_type == "Debug":
-            tools.replace_in_file("freetype2.pc", "-lfreetype", "-lfreetyped")
+            content = tools.load("freetype2.pc")
+            content = re.sub("-lfreetype(?!d)", "-lfreetyped", content)
+            content = content.encode("utf-8")
+            with open("freetype2.pc", "wb") as handle:
+                handle.write(content)
 
     def build(self):
         # Patch files from dependencies

--- a/conanfile.py
+++ b/conanfile.py
@@ -27,7 +27,7 @@ class FontconfigConan(ConanFile):
 
     def requirements(self):
         self.requires("freetype/2.10.0@bincrafters/stable")
-        self.requires("Expat/2.2.6@pix4d/stable")
+        self.requires("expat/2.2.7")
         if self.settings.os == "Linux":
             self.requires("libuuid/1.0.3@bincrafters/stable")
 


### PR DESCRIPTION
Hi.

In commit  43e6f058612a7b433e1da02556277c2d33d626e3 code below was added:

```python
        if self.settings.build_type == "Debug":
            tools.replace_in_file("freetype2.pc", "-lfreetype", "-lfreetyped")
```

which will broke if the pkg-config file already contains "-lfreetyped", changing it into "-lfreetypedd"(https://travis-ci.com/cqjjjzr/conan-libass/jobs/231041120). So we should use regexp to check such situation.

also, I found that gcc9 and clang8 are not in Travis CI config, so I append them into it.