### PR TITLE
Fix rename of zlib's pkg-config file

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -63,7 +63,6 @@ class FontconfigConan(ConanFile):
         #  - fontconfig requires libtool version number, change it for the corresponding freetype one
         tools.replace_in_file(os.path.join(self._source_subfolder, 'configure'), '21.0.15', '2.8.1')
         os.rename('freetype.pc', 'freetype2.pc')
-        os.rename('ZLIB.pc', 'zlib.pc')
 
     def build(self):
         # Patch files from dependencies


### PR DESCRIPTION
The `ZLIB.pc` file should be `zlib.pc`. In some cases, the file already has the correct name. Detect this and don't unconditionally attempt to rename a file that might not exist.