### PR TITLE
Change name of CMake target to 'Fontconfig'

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -86,5 +86,5 @@ class FontconfigConan(ConanFile):
         if self.settings.os == "Linux":
             self.cpp_info.libs.extend(["m", "pthread"])
         self.env_info.PATH.append(os.path.join(self.package_folder, 'bin'))
-        self.cpp_info.name = "Fontconfig"
-        self.cpp_info.names["pkg_config"] = "fontconfig"
+        self.cpp_info.names["cmake_find_package"] = "Fontconfig"
+        self.cpp_info.names["cmake_find_package_multi"] = "Fontconfig"

--- a/conanfile.py
+++ b/conanfile.py
@@ -86,4 +86,5 @@ class FontconfigConan(ConanFile):
         if self.settings.os == "Linux":
             self.cpp_info.libs.extend(["m", "pthread"])
         self.env_info.PATH.append(os.path.join(self.package_folder, 'bin'))
-
+        self.cpp_info.name = "Fontconfig"
+        self.cpp_info.names["pkg_config"] = "fontconfig"

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -4,7 +4,9 @@ project(PackageTest C)
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
+find_package(Fontconfig REQUIRED)
+
 add_executable(example example.c)
-target_link_libraries(example ${CONAN_LIBS})
+target_link_libraries(example Fontconfig::Fontconfig)
 set_target_properties(example PROPERTIES C_STANDARD 99)
 

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -6,7 +6,7 @@ from conans import ConanFile, CMake, tools, RunEnvironment
 
 class FontconfigTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake"
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)


### PR DESCRIPTION
According to CMake module the name should be `Fontconfig`: https://cmake.org/cmake/help/v3.14/module/FindFontconfig.html

I've also modified the `test_package` to use the target with `find_cmake_package` generator